### PR TITLE
Added the bcrypt library to hash/unhash user password before saving to MongoDB

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -3,11 +3,31 @@
   "opts": {
     "template": "node_modules/docdash",
     "destination": "./docs",
-    "recurse": true
+    "recurse": true,
+    "verbose": true
+  },
+  "source": {
+    "includePattern": ".+\\.js(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
   },
   "docdash": {
     "search": true,
+    "sectionOrder": [
+      "Modules",
+      "Classes",
+      "Global",
+      "Externals",
+      "Events",
+      "Namespaces",
+      "Tutorials",
+      "Interfaces"
+    ],
     "sort": true,
-    "private": false
+    "private": false,
+    "wrap": true
+  },
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": ["jsdoc", "closure"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/src/controller.js
+++ b/src/controller.js
@@ -55,11 +55,10 @@ async function getAuth(req, res) {
         res.status(404).send();
       }
       // Compares the provided password with the stored hashed password
-      const isPasswordMatch = await userModel
-        .findById(user._id)
-        .then((u) => u.comparePassword(authorizationData.password));
+      const userRecord = await userModel.findById(user._id);
+      const passwordsMatch = await userRecord.comparePassword(authorizationData.password);
 
-      if (!isPasswordMatch) {
+      if (!passwordsMatch) {
         res.setHeader("WWW-Authenticate", 'Basic realm="user"');
         res.status(401).send();
       } else {

--- a/src/controller.js
+++ b/src/controller.js
@@ -53,7 +53,13 @@ async function getAuth(req, res) {
       const user = await userModel.findOne({ email: authorizationData.userId }).lean();
       if (!user) {
         res.status(404).send();
-      } else if (authorizationData.password !== user.password) {
+      }
+      // Compares the provided password with the stored hashed password
+      const isPasswordMatch = await userModel
+        .findById(user._id)
+        .then((u) => u.comparePassword(authorizationData.password));
+
+      if (!isPasswordMatch) {
         res.setHeader("WWW-Authenticate", 'Basic realm="user"');
         res.status(401).send();
       } else {

--- a/src/controller.js
+++ b/src/controller.js
@@ -56,7 +56,7 @@ async function getAuth(req, res) {
       }
       // Compares the provided password with the stored hashed password
       const userRecord = await userModel.findById(user._id);
-      const passwordsMatch = await userRecord.comparePassword(authorizationData.password);
+      const passwordsMatch = await userRecord.passwordMatches(authorizationData.password);
 
       if (!passwordsMatch) {
         res.setHeader("WWW-Authenticate", 'Basic realm="user"');

--- a/src/model.js
+++ b/src/model.js
@@ -13,6 +13,8 @@ const database = await mongoose.connect(connectionString);
 const learnerSchema = new mongoose.Schema({});
 const instructorSchema = new mongoose.Schema({});
 
+const SALT_ROUNDS = 10;
+
 const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
@@ -25,9 +27,8 @@ const userSchema = new mongoose.Schema({
 userSchema.pre("save", async function (next) {
   if (this.isModified("password")) {
     try {
-      const hashedPassword = await bcrypt.hash(this.password, 10);
-      this.password = hashedPassword;
-      this.set(`password`, this.password);
+      const salt = await bcrypt.genSalt(SALT_ROUNDS);
+      this.password = await bcrypt.hash(this.password, salt);
     } catch (err) {
       next(err); // Pass any errors to the next middleware
     }

--- a/src/model.js
+++ b/src/model.js
@@ -2,6 +2,16 @@ import mongoose from "mongoose";
 import dotenv from "dotenv";
 import bcrypt from "bcrypt";
 
+/**
+ * The the cost of processing the data for generating a hash.
+ *
+ * See {@link https://www.npmjs.com/package/bcrypt#a-note-on-rounds bcrypt -- A Note on Rounds} for
+ * more information on what this value means and how it affects performance.
+ *
+ * @constant
+ * @type {number}
+ * @default
+ */
 const BCRYPT_NUM_SALT_ROUNDS = 10;
 
 dotenv.config();
@@ -14,6 +24,18 @@ const database = await mongoose.connect(connectionString);
 
 const learnerSchema = new mongoose.Schema({});
 const instructorSchema = new mongoose.Schema({});
+
+/**
+ * User schema for the database.
+ *
+ * @kind class
+ * @property {string} name - The name of the user.
+ * @property {string} email - The email of the user (unique).
+ * @property {string} password - The user's password (will be encrypted when document is saved).
+ * @property {object} learnerData - The learner data associated with the user.
+ * @property {object} [instructorData] - The instructor data associated with the user (optional).
+ * @mixes userSchema.methods
+ */
 const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
@@ -22,26 +44,21 @@ const userSchema = new mongoose.Schema({
   instructorData: { type: instructorSchema }
 });
 
-// Detects change to the password field, both password update and password creation, then hashes the password before persistance
-userSchema.pre("save", async function (next) {
-    console.assert(typeof next === "function");
-    if (this.isModified("password")) {
-      try {
-        const salt = await bcrypt.genSalt(BCRYPT_NUM_SALT_ROUNDS);
-        this.password = await bcrypt.hash(this.password, salt);
-        next();
-      } catch (error) {
-        next(error);
-      }
-    } else {
-      next();
-    }
-  });
+/** @mixin */
+userSchema.methods;
 
-// Method to compare input password with hashed password in DB
+/**
+ * Compares a user-supplied password with the document's encrypted password to see if it matches.
+ *
+ * @method
+ * @param {!string} password - The user-supplied password
+ * @returns {boolean} `true` if the password matches, `false` if it doesn't
+ * @throws {TypeError} `TypeError` if `password` is not a string
+ */
 userSchema.methods.passwordMatches = async function (password) {
   if (typeof password !== "string")
     throw new TypeError("\"password\" must be a string");
+
   try {
     return await bcrypt.compare(password, this.password);
   } catch (error) {
@@ -57,6 +74,28 @@ userSchema.methods.passwordMatches = async function (password) {
     return false;
   }
 };
+
+userSchema.pre("save",
+  /*
+  If a document's ".password" member has been modified then encrypt it before storing it in the
+  database.
+
+  @param {!function} next - The function that invokes subsequent middleware.
+  */
+  async function (next) {
+    console.assert(typeof next === "function");
+    if (this.isModified("password")) {
+      try {
+        const salt = await bcrypt.genSalt(BCRYPT_NUM_SALT_ROUNDS);
+        this.password = await bcrypt.hash(this.password, salt);
+        next();
+      } catch (error) {
+        next(error);
+      }
+    } else {
+      next();
+    }
+  });
 
 const userModel = database.model("users", userSchema);
 const learnerModel = database.model("learner", learnerSchema);


### PR DESCRIPTION
## Why was this PR opened?
To review the addition of the bcrypt library that is used for hashing/unhashing user passwords before saving to MongoDB.

## Brief Description


## Unrelated Changes
None.

## UI Screenshots
![image](https://github.com/user-attachments/assets/48d023e1-6558-45dc-bcec-6e784cfe2fb9)
The unhashed user password is "test".

## Link to Referenced Trello Cards
https://trello.com/c/PHPaDxf8/29-use-an-encryption-package-to-encrypt-passwords-before-theyre-stored-in-mongodb

## Mentions
@kwoodman1970 